### PR TITLE
Add fabriceNode GET API support

### DIFF
--- a/client/fabricNode_service.go
+++ b/client/fabricNode_service.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"fmt"
+	"github.com/ciscoecosystem/aci-go-client/models"
+)
+
+func (sm *ServiceManager) ReadFabricNode(pod int, node int) (*models.FabricNode, error) {
+	dn := fmt.Sprintf("topology/pod-%d/node-%d", pod, node)
+	cont, err := sm.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+	fabricNode := models.FabricNodeFromContainer(cont)
+	return fabricNode, nil
+}
+
+func (sm *ServiceManager) ListFabricNode() ([]*models.FabricNode, error) {
+	baseurlStr := "/api/node/class"
+	dnUrl := fmt.Sprintf("%s/fabricNode.json", baseurlStr)
+	cont, err := sm.GetViaURL(dnUrl)
+	list := models.FabricNodeListFromContainer(cont)
+	return list, err
+}

--- a/client/l3extRsNodeL3OutAtt_service.go
+++ b/client/l3extRsNodeL3OutAtt_service.go
@@ -4,66 +4,50 @@ import (
 	"fmt"
 
 	"github.com/ciscoecosystem/aci-go-client/models"
-
-
-
-	
-
-
 )
 
-
-
-
-
-
-
-
-
-func (sm *ServiceManager) CreateFabricNode(tDn string ,logical_node_profile string ,l3_outside string ,tenant string , description string, l3extRsNodeL3OutAttattr models.FabricNodeAttributes) (*models.FabricNode, error) {	
-	rn := fmt.Sprintf("rsnodeL3OutAtt-[%s]",tDn)
-	parentDn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", tenant ,l3_outside ,logical_node_profile )
-	l3extRsNodeL3OutAtt := models.NewFabricNode(rn, parentDn, description, l3extRsNodeL3OutAttattr)
+func (sm *ServiceManager) CreateL3extRsNodeL3OutAtt(tDn string, logical_node_profile string, l3_outside string, tenant string, description string, l3extRsNodeL3OutAttattr models.L3extRsNodeL3OutAttAttributes) (*models.L3extRsNodeL3OutAtt, error) {
+	rn := fmt.Sprintf("rsnodeL3OutAtt-[%s]", tDn)
+	parentDn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", tenant, l3_outside, logical_node_profile)
+	l3extRsNodeL3OutAtt := models.NewL3extRsNodeL3OutAtt(rn, parentDn, description, l3extRsNodeL3OutAttattr)
 	err := sm.Save(l3extRsNodeL3OutAtt)
 	return l3extRsNodeL3OutAtt, err
 }
 
-func (sm *ServiceManager) ReadFabricNode(tDn string ,logical_node_profile string ,l3_outside string ,tenant string ) (*models.FabricNode, error) {
-	dn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]", tenant ,l3_outside ,logical_node_profile ,tDn )    
+func (sm *ServiceManager) ReadL3extRsNodeL3OutAtt(tDn string, logical_node_profile string, l3_outside string, tenant string) (*models.L3extRsNodeL3OutAtt, error) {
+	dn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]", tenant, l3_outside, logical_node_profile, tDn)
 	cont, err := sm.Get(dn)
 	if err != nil {
 		return nil, err
 	}
 
-	l3extRsNodeL3OutAtt := models.FabricNodeFromContainer(cont)
+	l3extRsNodeL3OutAtt := models.L3extRsNodeL3OutAttFromContainer(cont)
 	return l3extRsNodeL3OutAtt, nil
 }
 
-func (sm *ServiceManager) DeleteFabricNode(tDn string ,logical_node_profile string ,l3_outside string ,tenant string ) error {
-	dn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]", tenant ,l3_outside ,logical_node_profile ,tDn )
+func (sm *ServiceManager) DeleteL3extRsNodeL3OutAtt(tDn string, logical_node_profile string, l3_outside string, tenant string) error {
+	dn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]", tenant, l3_outside, logical_node_profile, tDn)
 	return sm.DeleteByDn(dn, models.L3extrsnodel3outattClassName)
 }
 
-func (sm *ServiceManager) UpdateFabricNode(tDn string ,logical_node_profile string ,l3_outside string ,tenant string  ,description string, l3extRsNodeL3OutAttattr models.FabricNodeAttributes) (*models.FabricNode, error) {
-	rn := fmt.Sprintf("rsnodeL3OutAtt-[%s]",tDn)
-	parentDn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", tenant ,l3_outside ,logical_node_profile )
-	l3extRsNodeL3OutAtt := models.NewFabricNode(rn, parentDn, description, l3extRsNodeL3OutAttattr)
+func (sm *ServiceManager) UpdateL3extRsNodeL3OutAtt(tDn string, logical_node_profile string, l3_outside string, tenant string, description string, l3extRsNodeL3OutAttattr models.L3extRsNodeL3OutAttAttributes) (*models.L3extRsNodeL3OutAtt, error) {
+	rn := fmt.Sprintf("rsnodeL3OutAtt-[%s]", tDn)
+	parentDn := fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", tenant, l3_outside, logical_node_profile)
+	l3extRsNodeL3OutAtt := models.NewL3extRsNodeL3OutAtt(rn, parentDn, description, l3extRsNodeL3OutAttattr)
 
-    l3extRsNodeL3OutAtt.Status = "modified"
+	l3extRsNodeL3OutAtt.Status = "modified"
 	err := sm.Save(l3extRsNodeL3OutAtt)
 	return l3extRsNodeL3OutAtt, err
 
 }
 
-func (sm *ServiceManager) ListFabricNode(logical_node_profile string ,l3_outside string ,tenant string ) ([]*models.FabricNode, error) {
+func (sm *ServiceManager) ListL3extRsNodeL3OutAtt(logical_node_profile string, l3_outside string, tenant string) ([]*models.L3extRsNodeL3OutAtt, error) {
 
-	baseurlStr := "/api/node/class"	
-	dnUrl := fmt.Sprintf("%s/uni/tn-%s/out-%s/lnodep-%s/l3extRsNodeL3OutAtt.json", baseurlStr , tenant ,l3_outside ,logical_node_profile )
-    
-    cont, err := sm.GetViaURL(dnUrl)
-	list := models.FabricNodeListFromContainer(cont)
+	baseurlStr := "/api/node/class"
+	dnUrl := fmt.Sprintf("%s/uni/tn-%s/out-%s/lnodep-%s/l3extRsNodeL3OutAtt.json", baseurlStr, tenant, l3_outside, logical_node_profile)
+
+	cont, err := sm.GetViaURL(dnUrl)
+	list := models.L3extRsNodeL3OutAttListFromContainer(cont)
 
 	return list, err
 }
-
-

--- a/models/fabric_node.go
+++ b/models/fabric_node.go
@@ -1,0 +1,144 @@
+package models
+
+import (
+	"strconv"
+
+	"github.com/ciscoecosystem/aci-go-client/container"
+)
+
+const FabricNodeClassName = "fabricNode"
+
+type FabricNode struct {
+	BaseAttributes
+	FabricNodeAttributes
+}
+
+type FabricNodeAttributes struct {
+	AdSt             string `json:",omitempty"`
+	Address          string `json:",omitempty"`
+	Annotation       string `json:",omitempty"`
+	ApicType         string `json:",omitempty"`
+	DelayedHeartbeat string `json:",omitempty"`
+	ExtMngdBy        string `json:",omitempty"`
+	FabricSt         string `json:",omitempty"`
+	Id               string `json:",omitempty"`
+	LastStateModTs   string `json:",omitempty"`
+	ModTs            string `json:",omitempty"`
+	Model            string `json:",omitempty"`
+	MonPolDn         string `json:",omitempty"`
+	Name             string `json:",omitempty"`
+	NameAlias        string `json:",omitempty"`
+	NodeType         string `json:",omitempty"`
+	Role             string `json:",omitempty"`
+	Serial           string `json:",omitempty"`
+	Uid              string `json:",omitempty"`
+	Userdom          string `json:",omitempty"`
+	Vendor           string `json:",omitempty"`
+	Version          string `json:",omitempty"`
+}
+
+/*
+ * No NewFabricNode as this is a non-configurable MO
+func NewFabricNode(fabricNodeRn, parentDn, description string, fabricNodeattr FabricNodeAttributes) *FabricNode {
+    dn := fmt.Sprintf("%s/%s", parentDn, fabricNodeRn)
+    return &FabricNode{
+        BaseAttributes: BaseAttributes{
+            DistinguishedName: dn,
+            Description:       description,
+            Status:            "created, modified",
+            ClassName:         FabricNodeClassName,
+            Rn:                fabricNodeRn,
+        },
+
+        FabricNodeAttributes: fabricNodeattr,
+
+    }
+}
+*/
+
+func (fabricNode *FabricNode) ToMap() (map[string]string, error) {
+	fabricNodeMap, err := fabricNode.BaseAttributes.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	A(fabricNodeMap, "adSt", fabricNode.AdSt)
+	A(fabricNodeMap, "address", fabricNode.Address)
+	A(fabricNodeMap, "annotation", fabricNode.Annotation)
+	A(fabricNodeMap, "apicType", fabricNode.ApicType)
+	A(fabricNodeMap, "delayedHeartbeat", fabricNode.DelayedHeartbeat)
+	A(fabricNodeMap, "extMngdBy", fabricNode.ExtMngdBy)
+	A(fabricNodeMap, "fabricSt", fabricNode.FabricSt)
+	A(fabricNodeMap, "id", fabricNode.Id)
+	A(fabricNodeMap, "lastStateModTs", fabricNode.LastStateModTs)
+	A(fabricNodeMap, "modTs", fabricNode.ModTs)
+	A(fabricNodeMap, "model", fabricNode.Model)
+	A(fabricNodeMap, "monPolDn", fabricNode.MonPolDn)
+	A(fabricNodeMap, "name", fabricNode.Name)
+	A(fabricNodeMap, "nameAlias", fabricNode.NameAlias)
+	A(fabricNodeMap, "nodeType", fabricNode.NodeType)
+	A(fabricNodeMap, "role", fabricNode.Role)
+	A(fabricNodeMap, "serial", fabricNode.Serial)
+	A(fabricNodeMap, "uid", fabricNode.Uid)
+	A(fabricNodeMap, "userdom", fabricNode.Userdom)
+	A(fabricNodeMap, "vendor", fabricNode.Vendor)
+	A(fabricNodeMap, "version", fabricNode.Version)
+
+	return fabricNodeMap, err
+}
+
+func FabricNodeFromContainerList(cont *container.Container, index int) *FabricNode {
+
+	FabricNodeCont := cont.S("imdata").Index(index).S(FabricNodeClassName, "attributes")
+	return &FabricNode{
+		BaseAttributes{
+			DistinguishedName: G(FabricNodeCont, "dn"),
+			Description:       G(FabricNodeCont, "descr"),
+			Status:            G(FabricNodeCont, "status"),
+			ClassName:         FabricNodeClassName,
+			Rn:                G(FabricNodeCont, "rn"),
+		},
+
+		FabricNodeAttributes{
+			AdSt:             G(FabricNodeCont, "adSt"),
+			Address:          G(FabricNodeCont, "address"),
+			Annotation:       G(FabricNodeCont, "annotation"),
+			ApicType:         G(FabricNodeCont, "apicType"),
+			DelayedHeartbeat: G(FabricNodeCont, "delayedHeartbeat"),
+			ExtMngdBy:        G(FabricNodeCont, "extMngdBy"),
+			FabricSt:         G(FabricNodeCont, "fabricSt"),
+			Id:               G(FabricNodeCont, "id"),
+			LastStateModTs:   G(FabricNodeCont, "lastStateModTs"),
+			ModTs:            G(FabricNodeCont, "modTs"),
+			Model:            G(FabricNodeCont, "model"),
+			MonPolDn:         G(FabricNodeCont, "monPolDn"),
+			Name:             G(FabricNodeCont, "name"),
+			NameAlias:        G(FabricNodeCont, "nameAlias"),
+			NodeType:         G(FabricNodeCont, "nodeType"),
+			Role:             G(FabricNodeCont, "role"),
+			Serial:           G(FabricNodeCont, "serial"),
+			Uid:              G(FabricNodeCont, "uid"),
+			Userdom:          G(FabricNodeCont, "userdom"),
+			Vendor:           G(FabricNodeCont, "vendor"),
+			Version:          G(FabricNodeCont, "version"),
+		},
+	}
+}
+
+func FabricNodeFromContainer(cont *container.Container) *FabricNode {
+
+	return FabricNodeFromContainerList(cont, 0)
+}
+
+func FabricNodeListFromContainer(cont *container.Container) []*FabricNode {
+	length, _ := strconv.Atoi(G(cont, "totalCount"))
+
+	arr := make([]*FabricNode, length)
+
+	for i := 0; i < length; i++ {
+
+		arr[i] = FabricNodeFromContainerList(cont, i)
+	}
+
+	return arr
+}

--- a/models/l3ext_rs_node_l3_out_att.go
+++ b/models/l3ext_rs_node_l3_out_att.go
@@ -9,12 +9,12 @@ import (
 
 const L3extrsnodel3outattClassName = "l3extRsNodeL3OutAtt"
 
-type FabricNode struct {
+type L3extRsNodeL3OutAtt struct {
 	BaseAttributes
-	FabricNodeAttributes
+	L3extRsNodeL3OutAttAttributes
 }
 
-type FabricNodeAttributes struct {
+type L3extRsNodeL3OutAttAttributes struct {
 	TDn string `json:",omitempty"`
 
 	Annotation string `json:",omitempty"`
@@ -26,9 +26,9 @@ type FabricNodeAttributes struct {
 	RtrIdLoopBack string `json:",omitempty"`
 }
 
-func NewFabricNode(l3extRsNodeL3OutAttRn, parentDn, description string, l3extRsNodeL3OutAttattr FabricNodeAttributes) *FabricNode {
+func NewL3extRsNodeL3OutAtt(l3extRsNodeL3OutAttRn, parentDn, description string, l3extRsNodeL3OutAttattr L3extRsNodeL3OutAttAttributes) *L3extRsNodeL3OutAtt {
 	dn := fmt.Sprintf("%s/%s", parentDn, l3extRsNodeL3OutAttRn)
-	return &FabricNode{
+	return &L3extRsNodeL3OutAtt{
 		BaseAttributes: BaseAttributes{
 			DistinguishedName: dn,
 			Description:       description,
@@ -37,11 +37,11 @@ func NewFabricNode(l3extRsNodeL3OutAttRn, parentDn, description string, l3extRsN
 			Rn:                l3extRsNodeL3OutAttRn,
 		},
 
-		FabricNodeAttributes: l3extRsNodeL3OutAttattr,
+		L3extRsNodeL3OutAttAttributes: l3extRsNodeL3OutAttattr,
 	}
 }
 
-func (l3extRsNodeL3OutAtt *FabricNode) ToMap() (map[string]string, error) {
+func (l3extRsNodeL3OutAtt *L3extRsNodeL3OutAtt) ToMap() (map[string]string, error) {
 	l3extRsNodeL3OutAttMap, err := l3extRsNodeL3OutAtt.BaseAttributes.ToMap()
 	if err != nil {
 		return nil, err
@@ -60,46 +60,46 @@ func (l3extRsNodeL3OutAtt *FabricNode) ToMap() (map[string]string, error) {
 	return l3extRsNodeL3OutAttMap, err
 }
 
-func FabricNodeFromContainerList(cont *container.Container, index int) *FabricNode {
+func L3extRsNodeL3OutAttFromContainerList(cont *container.Container, index int) *L3extRsNodeL3OutAtt {
 
-	FabricNodeCont := cont.S("imdata").Index(index).S(L3extrsnodel3outattClassName, "attributes")
-	return &FabricNode{
+	L3extRsNodeL3OutAttCont := cont.S("imdata").Index(index).S(L3extrsnodel3outattClassName, "attributes")
+	return &L3extRsNodeL3OutAtt{
 		BaseAttributes{
-			DistinguishedName: G(FabricNodeCont, "dn"),
-			Description:       G(FabricNodeCont, "descr"),
-			Status:            G(FabricNodeCont, "status"),
+			DistinguishedName: G(L3extRsNodeL3OutAttCont, "dn"),
+			Description:       G(L3extRsNodeL3OutAttCont, "descr"),
+			Status:            G(L3extRsNodeL3OutAttCont, "status"),
 			ClassName:         L3extrsnodel3outattClassName,
-			Rn:                G(FabricNodeCont, "rn"),
+			Rn:                G(L3extRsNodeL3OutAttCont, "rn"),
 		},
 
-		FabricNodeAttributes{
+		L3extRsNodeL3OutAttAttributes{
 
-			TDn: G(FabricNodeCont, "tDn"),
+			TDn: G(L3extRsNodeL3OutAttCont, "tDn"),
 
-			Annotation: G(FabricNodeCont, "annotation"),
+			Annotation: G(L3extRsNodeL3OutAttCont, "annotation"),
 
-			ConfigIssues: G(FabricNodeCont, "configIssues"),
+			ConfigIssues: G(L3extRsNodeL3OutAttCont, "configIssues"),
 
-			RtrId: G(FabricNodeCont, "rtrId"),
+			RtrId: G(L3extRsNodeL3OutAttCont, "rtrId"),
 
-			RtrIdLoopBack: G(FabricNodeCont, "rtrIdLoopBack"),
+			RtrIdLoopBack: G(L3extRsNodeL3OutAttCont, "rtrIdLoopBack"),
 		},
 	}
 }
 
-func FabricNodeFromContainer(cont *container.Container) *FabricNode {
+func L3extRsNodeL3OutAttFromContainer(cont *container.Container) *L3extRsNodeL3OutAtt {
 
-	return FabricNodeFromContainerList(cont, 0)
+	return L3extRsNodeL3OutAttFromContainerList(cont, 0)
 }
 
-func FabricNodeListFromContainer(cont *container.Container) []*FabricNode {
+func L3extRsNodeL3OutAttListFromContainer(cont *container.Container) []*L3extRsNodeL3OutAtt {
 	length, _ := strconv.Atoi(G(cont, "totalCount"))
 
-	arr := make([]*FabricNode, length)
+	arr := make([]*L3extRsNodeL3OutAtt, length)
 
 	for i := 0; i < length; i++ {
 
-		arr[i] = FabricNodeFromContainerList(cont, i)
+		arr[i] = L3extRsNodeL3OutAttFromContainerList(cont, i)
 	}
 
 	return arr


### PR DESCRIPTION
    - Add fabricNode Model/Client Support
    - Rename fabricNode associated with l3extRsNodeL3OutAtt MO
        - In this case the target is the fabricNode, but the model itself assumes the relation MO is the fabric MO
        - In order to provide consistent naming, I've made the change in the l3extRsNodeL3OutAtt related files