### PR TITLE
Removing explicit status value for firmwareOSource MO.

### DIFF
--- a/client/firmwareOSource_service.go
+++ b/client/firmwareOSource_service.go
@@ -57,6 +57,7 @@ func (sm *ServiceManager) CreateOSource(name string, description string, firmwar
 	rn := fmt.Sprintf("osrc-%s", name)
 	parentDn := fmt.Sprintf("uni/fabric/fwrepop")
 	firmwareOSource := models.NewOSource(rn, parentDn, description, firmwareOSourceAttr)
+	firmwareOSource.Status = ""  // this avoids API failure in case MO is already created in APIC
 	err := sm.Save(firmwareOSource)
 	return firmwareOSource, err
 }
@@ -80,7 +81,7 @@ func (sm *ServiceManager) UpdateOSource(name string, description string, firmwar
 	rn := fmt.Sprintf("osrc-%s", name)
 	parentDn := fmt.Sprintf("uni/fabric/fwrepop")
 	firmwareOSource := models.NewOSource(rn, parentDn, description, firmwareOSourceAttr)
-	firmwareOSource.Status = "modified"
+	firmwareOSource.Status = ""  // this avoids API failure in case MO is not created in APIC
 	err := sm.Save(firmwareOSource)
 	return firmwareOSource, err
 

--- a/client/firmwareOSource_service.go
+++ b/client/firmwareOSource_service.go
@@ -57,7 +57,6 @@ func (sm *ServiceManager) CreateOSource(name string, description string, firmwar
 	rn := fmt.Sprintf("osrc-%s", name)
 	parentDn := fmt.Sprintf("uni/fabric/fwrepop")
 	firmwareOSource := models.NewOSource(rn, parentDn, description, firmwareOSourceAttr)
-	firmwareOSource.Status = ""  // this avoids API failure in case MO is already created in APIC
 	err := sm.Save(firmwareOSource)
 	return firmwareOSource, err
 }
@@ -81,7 +80,6 @@ func (sm *ServiceManager) UpdateOSource(name string, description string, firmwar
 	rn := fmt.Sprintf("osrc-%s", name)
 	parentDn := fmt.Sprintf("uni/fabric/fwrepop")
 	firmwareOSource := models.NewOSource(rn, parentDn, description, firmwareOSourceAttr)
-	firmwareOSource.Status = ""  // this avoids API failure in case MO is not created in APIC
 	err := sm.Save(firmwareOSource)
 	return firmwareOSource, err
 

--- a/models/firmware_o_source.go
+++ b/models/firmware_o_source.go
@@ -194,7 +194,7 @@ func NewOSource(firmwareOSourceRn, parentDn, description string, firmwareOSource
 		BaseAttributes: BaseAttributes{
 			DistinguishedName: dn,
 			Description:       description,
-			Status:            "created, modified",
+			Status:            "",
 			ClassName:         FirmwareOSourceClassName,
 			Rn:                firmwareOSourceRn,
 		},


### PR DESCRIPTION
This diff removes explicit value setting code for status field in firmwareOSource MO.
It is done this way so create API does not fail in case MO is already present in APIC.
Also, update API does not fail if MO is not present in APIC.