### PR TITLE
Returning error when HTTP response is not OK

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -244,6 +244,10 @@ func (c *Client) Authenticate() error {
 	if obj == nil {
 		return errors.New("Empty response")
 	}
+	err = CheckForErrors(obj, method)
+	if err != nil {
+		return err
+	}
 
 	token := obj.S("imdata").Index(0).S("aaaLogin", "attributes", "token").String()
 	creationTimeStr := stripQuotes(obj.S("imdata").Index(0).S("aaaLogin", "attributes", "creationTime").String())
@@ -288,9 +292,6 @@ func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, er
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	bodyStr := string(bodyBytes)
-	if resp.StatusCode >= 400 {
-		return nil, nil, errors.New(resp.Status + ". Response body: " + bodyStr)
-	}
 	resp.Body.Close()
 	log.Printf("\n HTTP response unique string %s %s %s", req.Method, req.URL.String(), bodyStr)
 	obj, err := container.ParseJSON(bodyBytes)

--- a/client/client.go
+++ b/client/client.go
@@ -288,6 +288,9 @@ func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, er
 
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	bodyStr := string(bodyBytes)
+	if resp.StatusCode >= 400 {
+		return nil, nil, errors.New(resp.Status + ". Response body: " + bodyStr)
+	}
 	resp.Body.Close()
 	log.Printf("\n HTTP response unique string %s %s %s", req.Method, req.URL.String(), bodyStr)
 	obj, err := container.ParseJSON(bodyBytes)


### PR DESCRIPTION
If HTTP response is not OK, "Do" method should return an error.
Otherwise, the caller does not get notified that something went wrong.
For instance, if user credentials is wrong for connecting to an APIC, the following was
returned when APIC was queried for some MOs:
    strconv.ParseInt: parsing "{}": invalid syntax
This is because the caller was expecting a certain response body format, and it didn't know
something went wrong. And the error message is misleading to the end-user.

After applying the changes, the following is what end-user sees:
    401 Unauthorized. Response body: {"totalCount":"1","imdata":[{"error":{"attributes":{"code":"401","text":"User credential is incorrect - FAILED local authentication"}}}]}