### PR TITLE
Add Support for APIC-Cookie via App Token Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,20 @@ Example,
     client.CreateTenant("tenant_name","description",tenantAttributesStruct)
     # tenantAttributesStruct is struct present in models/fv_tenant.go
 ```
+
+aci-go-client supports concurrent connections to different targets by calling client.NewClient() instead of client.GetClient().
+
+```golang
+client.NewClient("URL", "Username", client.PrivateKey("PrivateKey path"),client.AdminCert("Certificate name"), client.Insecure(true/false))
+```
+
+When making PyQuery calls (API calls which start with /mqapi2/), ensure that the APIC-Cookie is populated in the Requests
+as PyQuery may not function using only the Certificate-Based Request.
+
+If using Username/Password, no extra steps are necessary, as the APIC-Cookie will be obtained at the time of the API call.
+If using Certificate based authentication, call client.Authenticate() first, to obtain a recent APIC-Cookie authorization token
+PyQuery APIs currently do not support Certificate + Username authentication.
+
+```golang
+client.NewClient("URL", "Username", client.AppUserName("AppUserName"), client.PrivateKey("PrivateKey path"), client.AdminCert("Certificate name"), client.Insecure(true/false))
+```

--- a/client/auth.go
+++ b/client/auth.go
@@ -68,7 +68,7 @@ func (client *Client) InjectAuthenticationHeader(req *http.Request, path string)
 				})
 				return req, nil
 			}
-        }
+		}
 
 		var bodyStr string
 		if req.Method != "GET" {

--- a/client/auth.go
+++ b/client/auth.go
@@ -53,7 +53,6 @@ func (client *Client) InjectAuthenticationHeader(req *http.Request, path string)
 			if err != nil {
 				return nil, err
 			}
-
 		}
 		req.AddCookie(&http.Cookie{
 			Name:  "APIC-Cookie",
@@ -61,6 +60,16 @@ func (client *Client) InjectAuthenticationHeader(req *http.Request, path string)
 		})
 		return req, nil
 	} else if client.privatekey != "" && client.adminCert != "" {
+		if client.appUserName != "" {
+			if client.AuthToken != nil && client.AuthToken.IsValid() {
+				req.AddCookie(&http.Cookie{
+					Name:  "APIC-Cookie",
+					Value: client.AuthToken.Token,
+				})
+				return req, nil
+			}
+        }
+
 		var bodyStr string
 		if req.Method != "GET" {
 			buffer, _ := ioutil.ReadAll(req.Body)
@@ -76,11 +85,11 @@ func (client *Client) InjectAuthenticationHeader(req *http.Request, path string)
 			contentStr = fmt.Sprintf("%s%s", req.Method, path)
 
 		}
-		log.Printf("Content %s", contentStr)
+		log.Printf("[DEBUG] Content %s", contentStr)
 		content := []byte(contentStr)
 
 		signature, err := createSignature(content, client.privatekey)
-		log.Printf("signature %s" + signature)
+		log.Printf("[DEBUG] Signature %s", signature)
 		if err != nil {
 			return req, err
 		}
@@ -92,24 +101,26 @@ func (client *Client) InjectAuthenticationHeader(req *http.Request, path string)
 			Name:  "APIC-Certificate-Algorithm",
 			Value: "v1.0",
 		})
+
+		// Actual certificate fingerprint/thumbprint generation is not required
+		// Simply setting cookie to fingerprint is sufficient for cert-based requests.
 		req.AddCookie(&http.Cookie{
 			Name:  "APIC-Certificate-Fingerprint",
 			Value: "fingerprint",
 		})
 		if client.appUserName != "" {
-		   req.AddCookie(&http.Cookie{
-			Name:  "APIC-Certificate-DN",
-			Value: fmt.Sprintf("uni/userext/appuser-%s/usercert-%s", client.appUserName, client.adminCert),
-		    })
+			req.AddCookie(&http.Cookie{
+				Name:  "APIC-Certificate-DN",
+				Value: fmt.Sprintf("uni/userext/appuser-%s/usercert-%s", client.appUserName, client.adminCert),
+			})
 		} else {
-		    req.AddCookie(&http.Cookie{
-			Name:  "APIC-Certificate-DN",
-			Value: fmt.Sprintf("uni/userext/user-%s/usercert-%s", client.username, client.adminCert),
-		    })
+			req.AddCookie(&http.Cookie{
+				Name:  "APIC-Certificate-DN",
+				Value: fmt.Sprintf("uni/userext/user-%s/usercert-%s", client.username, client.adminCert),
+			})
 		}
 		log.Printf("[DEBUG] finished signature creation")
 		return req, nil
-
 	} else {
 
 		return req, fmt.Errorf("Anyone of password or privatekey/certificate name is must.")

--- a/client/syntheticMaintPSwitchDetails_service.go
+++ b/client/syntheticMaintPSwitchDetails_service.go
@@ -7,6 +7,12 @@ import (
 // This is a special operation which validations a target Switch (leaf/spine) config
 // Action keyword is "Validate" instead of List/Get/Create because there is no creation done on the APIC
 // In addition, the incoming MO is different then the outgoing MO
+
+// Notes: PyQuery Based Request
+// Requires a valid client APIC-Cookie to be present in the Header
+// Ways to obtain the APIC-Cooki:
+// (1) Use Username/Password for Client Authentication
+// (2) Call client.Authenticate() prior to calling this function for AppUserName+Cert based clients
 func (sm *ServiceManager) ValidateSyntheticSwitchMaintP(syntheticMaintPSwitchDetailsattr models.MaintPSwitchDetailsAttributes) ([]*models.SwitchMaintPValidate, error) {
 	postUrlStr := "/mqapi2/deployment.query.json?mode=validateSwitchMaintP"
     rn := "switchDetails"

--- a/client/syntheticMaintPValidate_service.go
+++ b/client/syntheticMaintPValidate_service.go
@@ -4,6 +4,11 @@ import (
 	"fmt"
 	"github.com/ciscoecosystem/aci-go-client/models"
 )
+// Notes: PyQuery Based Request
+// Requires a valid client APIC-Cookie to be present in the Header
+// Ways to obtain the APIC-Cooki:
+// (1) Use Username/Password for Client Authentication
+// (2) Call client.Authenticate() prior to calling this function for AppUserName+Cert based clients
 
 func (sm *ServiceManager) ListSyntheticMaintPValidateCtrlrMaintP(targetVersion string) ([]*models.MaintPValidate, error) {
 	baseurlStr := "/mqapi2/deployment.query.json?mode=validateCtrlrMaintP"


### PR DESCRIPTION
Tested:

(1) Client APIs using Username/Password
(2) Client APIs using App Username + Certificate
(3) Client APIs using Standard Username + Certificate