### PR TITLE
Support httpClient to be set as an option.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -110,6 +110,8 @@ func ProxyUrl(pUrl string) Option {
 	}
 }
 
+// HttpClient option: allows for caller to set 'httpClient' with 'Transport'.
+// When this option is set 'client.proxyUrl' option is ignored.
 func HttpClient(httpcl *http.Client) Option {
 	return func(client *Client) {
 		client.httpClient = httpcl

--- a/client/client.go
+++ b/client/client.go
@@ -154,12 +154,12 @@ func initClient(clientUrl, username string, options ...Option) *Client {
 
 	if client.httpClient == nil {
 		transport = client.useInsecureHTTPClient(client.insecure)
+		if client.proxyUrl != "" {
+			transport = client.configProxy(transport)
+		}
 		client.httpClient = &http.Client{
 			Transport: transport,
 		}
-	}
-	if client.proxyUrl != "" {
-		client.configProxy(client.httpClient.transport)
 	}
 
 	var timeout time.Duration


### PR DESCRIPTION
This will enable the use of enhanced httpClient with retry mechanism instead of stock
http.Client(and Transport layer). For eg: 'https://pkg.go.dev/github.com/hashicorp/go-retryablehttp'.