### PR TITLE
Retain request body across multiple attempts

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -498,8 +498,15 @@ func StrtoInt(s string, startIndex int, bitSize int) (int64, error) {
 func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, error) {
 	log.Printf("[DEBUG] Begining Do method %s", req.URL.String())
 
+	// retain the request body across multiple attempts
+	var body []byte
+	if req.Body != nil {
+		body, _ = ioutil.ReadAll(req.Body)
+	}
+
 	for attempts := 0; ; attempts++ {
 		log.Printf("[TRACE] HTTP Request Method and URL: %s %s", req.Method, req.URL.String())
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 		if !c.skipLoggingPayload {
 			log.Printf("[TRACE] HTTP Request Body: %v", req.Body)
 		}
@@ -561,8 +568,15 @@ func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, er
 func (c *Client) DoRaw(req *http.Request) (*http.Response, error) {
 	log.Printf("[DEBUG] Begining DoRaw method %s", req.URL.String())
 
+	// retain the request body across multiple attempts
+	var body []byte
+	if req.Body != nil {
+		body, _ = ioutil.ReadAll(req.Body)
+	}
+
 	for attempts := 0; ; attempts++ {
 		log.Printf("[TRACE] HTTP Request Method and URL: %s %s", req.Method, req.URL.String())
+		req.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 		if !c.skipLoggingPayload {
 			log.Printf("[TRACE] HTTP Request Body: %v", req.Body)
 		}


### PR DESCRIPTION
`http.Request.Body` is of type `io.ReadCloser` which can be only read once. To retain the body across multiple attempts we need to store the body in a buffer and then restore from the buffer for each attempt.