### PR TITLE
Retry after 405 http response

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -529,7 +529,7 @@ func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, er
 			log.Printf("[DEBUG] HTTP response unique string %s %s %s", req.Method, req.URL.String(), bodyStr)
 		}
 
-		if resp.StatusCode < 500 || resp.StatusCode > 504 {
+		if (resp.StatusCode < 500 || resp.StatusCode > 504) && resp.StatusCode != 405 {
 			obj, err := container.ParseJSON(bodyBytes)
 			if err != nil {
 				log.Printf("[ERROR] Error occured while json parsing %+v", err)
@@ -543,7 +543,7 @@ func (c *Client) Do(req *http.Request) (*container.Container, *http.Response, er
 			if ok := c.backoff(attempts); !ok {
 				obj, err := container.ParseJSON(bodyBytes)
 				if err != nil {
-					log.Printf("[ERROR] Error occured while json parsing %+v with HTTP StatusCode 500-504", err)
+					log.Printf("[ERROR] Error occured while json parsing %+v with HTTP StatusCode 405, 500-504", err)
 					log.Printf("[DEBUG] Exit from Do method")
 					return nil, resp, err
 				}
@@ -585,7 +585,7 @@ func (c *Client) DoRaw(req *http.Request) (*http.Response, error) {
 			log.Printf("[TRACE] HTTP Response: %d %s", resp.StatusCode, resp.Status)
 		}
 
-		if resp.StatusCode < 500 || resp.StatusCode > 504 {
+		if (resp.StatusCode < 500 || resp.StatusCode > 504) && resp.StatusCode != 405 {
 			log.Printf("[DEBUG] Exit from DoRaw method")
 			return resp, nil
 		} else {


### PR DESCRIPTION
When deleting multiple objects intermittent HTTP 405 responses from APIC can be observed. This PR ensures that the retries mechanism is invoked after receiving 405s.