### PR TITLE
Added ReadRelationASNumber function to get all of the Set Path Prepend ASN objects

### DIFF
--- a/client/rtctrlSetASPathASN_service.go
+++ b/client/rtctrlSetASPathASN_service.go
@@ -48,7 +48,7 @@ func (sm *ServiceManager) ListASNumber(set_as_path_criteria string, action_rule_
 	return list, err
 }
 
-func (sm *ServiceManager) ReadRelationASNumber(parentDn string) ([]*container.Container, error) {
+func (sm *ServiceManager) ReadRelationSetASPathASN(parentDn string) ([]*container.Container, error) {
 	baseurlStr := "/api/node/class"
 	dnUrl := fmt.Sprintf("%s/%s/%s.json", baseurlStr, parentDn, "rtctrlSetASPathASN")
 	cont, err := sm.GetViaURL(dnUrl)

--- a/client/rtctrlSetASPathASN_service.go
+++ b/client/rtctrlSetASPathASN_service.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	"github.com/ciscoecosystem/aci-go-client/container"
 	"github.com/ciscoecosystem/aci-go-client/models"
 )
 
@@ -45,4 +46,17 @@ func (sm *ServiceManager) ListASNumber(set_as_path_criteria string, action_rule_
 	cont, err := sm.GetViaURL(dnUrl)
 	list := models.ASNumberListFromContainer(cont)
 	return list, err
+}
+
+func (sm *ServiceManager) ReadRelationASNumber(parentDn string) ([]*container.Container, error) {
+	baseurlStr := "/api/node/class"
+	dnUrl := fmt.Sprintf("%s/%s/%s.json", baseurlStr, parentDn, "rtctrlSetASPathASN")
+	cont, err := sm.GetViaURL(dnUrl)
+
+	if err != nil {
+		return nil, err
+	} else {
+		contList := models.ListFromContainer(cont, "rtctrlSetASPathASN")
+		return contList, nil
+	}
 }


### PR DESCRIPTION
Note:

Added ReadRelationASNumber function to get all of the Set Path Prepend ASN objects, PR belong to: https://github.com/CiscoDevNet/terraform-provider-aci/issues/826