### PR TITLE
Added leakRoutes to support leak internal subnet feature under the tenant networks vrf

### DIFF
--- a/client/leakRoutes_service.go
+++ b/client/leakRoutes_service.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/ciscoecosystem/aci-go-client/models"
+)
+
+func (sm *ServiceManager) CreateInterVRFLeakedRoutesContainer(vrf string, tenant string, description string, nameAlias string, leakRoutesAttr models.InterVRFLeakedRoutesContainerAttributes) (*models.InterVRFLeakedRoutesContainer, error) {
+	rn := fmt.Sprintf(models.RnleakRoutes)
+	parentDn := fmt.Sprintf(models.ParentDnleakRoutes, tenant, vrf)
+	leakRoutes := models.NewInterVRFLeakedRoutesContainer(rn, parentDn, description, nameAlias, leakRoutesAttr)
+	err := sm.Save(leakRoutes)
+	return leakRoutes, err
+}
+
+func (sm *ServiceManager) ReadInterVRFLeakedRoutesContainer(vrf string, tenant string) (*models.InterVRFLeakedRoutesContainer, error) {
+	dn := fmt.Sprintf(models.DnleakRoutes, tenant, vrf)
+
+	cont, err := sm.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+
+	leakRoutes := models.InterVRFLeakedRoutesContainerFromContainer(cont)
+	return leakRoutes, nil
+}
+
+func (sm *ServiceManager) DeleteInterVRFLeakedRoutesContainer(vrf string, tenant string) error {
+	dn := fmt.Sprintf(models.DnleakRoutes, tenant, vrf)
+	return sm.DeleteByDn(dn, models.LeakroutesClassName)
+}
+
+func (sm *ServiceManager) UpdateInterVRFLeakedRoutesContainer(vrf string, tenant string, description string, nameAlias string, leakRoutesAttr models.InterVRFLeakedRoutesContainerAttributes) (*models.InterVRFLeakedRoutesContainer, error) {
+	rn := fmt.Sprintf(models.RnleakRoutes)
+	parentDn := fmt.Sprintf(models.ParentDnleakRoutes, tenant, vrf)
+	leakRoutes := models.NewInterVRFLeakedRoutesContainer(rn, parentDn, description, nameAlias, leakRoutesAttr)
+	leakRoutes.Status = "modified"
+	err := sm.Save(leakRoutes)
+	return leakRoutes, err
+}
+
+func (sm *ServiceManager) ListInterVRFLeakedRoutesContainer(vrf string, tenant string) ([]*models.InterVRFLeakedRoutesContainer, error) {
+	dnUrl := fmt.Sprintf("%s/uni/tn-%s/ctx-%s/leakRoutes.json", models.BaseurlStr, tenant, vrf)
+	cont, err := sm.GetViaURL(dnUrl)
+	list := models.InterVRFLeakedRoutesContainerListFromContainer(cont)
+	return list, err
+}

--- a/models/leak_routes.go
+++ b/models/leak_routes.go
@@ -1,0 +1,98 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ciscoecosystem/aci-go-client/container"
+)
+
+const (
+	DnleakRoutes        = "uni/tn-%s/ctx-%s/leakroutes"
+	RnleakRoutes        = "leakroutes"
+	ParentDnleakRoutes  = "uni/tn-%s/ctx-%s"
+	LeakroutesClassName = "leakRoutes"
+)
+
+type InterVRFLeakedRoutesContainer struct {
+	BaseAttributes
+	NameAliasAttribute
+	InterVRFLeakedRoutesContainerAttributes
+}
+
+type InterVRFLeakedRoutesContainerAttributes struct {
+	Annotation string `json:",omitempty"`
+	Name       string `json:",omitempty"`
+}
+
+func NewInterVRFLeakedRoutesContainer(leakRoutesRn, parentDn, description, nameAlias string, leakRoutesAttr InterVRFLeakedRoutesContainerAttributes) *InterVRFLeakedRoutesContainer {
+	dn := fmt.Sprintf("%s/%s", parentDn, leakRoutesRn)
+	return &InterVRFLeakedRoutesContainer{
+		BaseAttributes: BaseAttributes{
+			DistinguishedName: dn,
+			Description:       description,
+			Status:            "created, modified",
+			ClassName:         LeakroutesClassName,
+			Rn:                leakRoutesRn,
+		},
+		NameAliasAttribute: NameAliasAttribute{
+			NameAlias: nameAlias,
+		},
+		InterVRFLeakedRoutesContainerAttributes: leakRoutesAttr,
+	}
+}
+
+func (leakRoutes *InterVRFLeakedRoutesContainer) ToMap() (map[string]string, error) {
+	leakRoutesMap, err := leakRoutes.BaseAttributes.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	alias, err := leakRoutes.NameAliasAttribute.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range alias {
+		A(leakRoutesMap, key, value)
+	}
+
+	A(leakRoutesMap, "annotation", leakRoutes.Annotation)
+	A(leakRoutesMap, "name", leakRoutes.Name)
+	return leakRoutesMap, err
+}
+
+func InterVRFLeakedRoutesContainerFromContainerList(cont *container.Container, index int) *InterVRFLeakedRoutesContainer {
+	InterVRFLeakedRoutesContainerCont := cont.S("imdata").Index(index).S(LeakroutesClassName, "attributes")
+	return &InterVRFLeakedRoutesContainer{
+		BaseAttributes{
+			DistinguishedName: G(InterVRFLeakedRoutesContainerCont, "dn"),
+			Description:       G(InterVRFLeakedRoutesContainerCont, "descr"),
+			Status:            G(InterVRFLeakedRoutesContainerCont, "status"),
+			ClassName:         LeakroutesClassName,
+			Rn:                G(InterVRFLeakedRoutesContainerCont, "rn"),
+		},
+		NameAliasAttribute{
+			NameAlias: G(InterVRFLeakedRoutesContainerCont, "nameAlias"),
+		},
+		InterVRFLeakedRoutesContainerAttributes{
+			Annotation: G(InterVRFLeakedRoutesContainerCont, "annotation"),
+			Name:       G(InterVRFLeakedRoutesContainerCont, "name"),
+		},
+	}
+}
+
+func InterVRFLeakedRoutesContainerFromContainer(cont *container.Container) *InterVRFLeakedRoutesContainer {
+	return InterVRFLeakedRoutesContainerFromContainerList(cont, 0)
+}
+
+func InterVRFLeakedRoutesContainerListFromContainer(cont *container.Container) []*InterVRFLeakedRoutesContainer {
+	length, _ := strconv.Atoi(G(cont, "totalCount"))
+	arr := make([]*InterVRFLeakedRoutesContainer, length)
+
+	for i := 0; i < length; i++ {
+		arr[i] = InterVRFLeakedRoutesContainerFromContainerList(cont, i)
+	}
+
+	return arr
+}


### PR DESCRIPTION
Note:

Added leakRoutes to support leak internal subnet feature under the tenant networks vrf, PR belongs to: https://github.com/CiscoDevNet/terraform-provider-aci/issues/554