### PR TITLE
Added Cloud APIC leakInternalPrefix model

### DIFF
--- a/client/leakInternalPrefix_service.go
+++ b/client/leakInternalPrefix_service.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/ciscoecosystem/aci-go-client/models"
+)
+
+func (sm *ServiceManager) CreateLeakInternalPrefix(ip string, vrf string, tenant string, description string, nameAlias string, leakInternalPrefixAttr models.LeakInternalPrefixAttributes) (*models.LeakInternalPrefix, error) {
+	rn := fmt.Sprintf(models.RnleakInternalPrefix, ip)
+	parentDn := fmt.Sprintf(models.ParentDnleakInternalPrefix, tenant, vrf)
+	leakInternalPrefix := models.NewLeakInternalPrefix(rn, parentDn, description, nameAlias, leakInternalPrefixAttr)
+	err := sm.Save(leakInternalPrefix)
+	return leakInternalPrefix, err
+}
+
+func (sm *ServiceManager) ReadLeakInternalPrefix(ip string, vrf string, tenant string) (*models.LeakInternalPrefix, error) {
+	dn := fmt.Sprintf(models.DnleakInternalPrefix, tenant, vrf, ip)
+
+	cont, err := sm.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+
+	leakInternalPrefix := models.LeakInternalPrefixFromContainer(cont)
+	return leakInternalPrefix, nil
+}
+
+func (sm *ServiceManager) DeleteLeakInternalPrefix(ip string, vrf string, tenant string) error {
+	dn := fmt.Sprintf(models.DnleakInternalPrefix, tenant, vrf, ip)
+	return sm.DeleteByDn(dn, models.LeakInternalPrefixClassName)
+}
+
+func (sm *ServiceManager) UpdateLeakInternalPrefix(ip string, vrf string, tenant string, description string, nameAlias string, leakInternalPrefixAttr models.LeakInternalPrefixAttributes) (*models.LeakInternalPrefix, error) {
+	rn := fmt.Sprintf(models.RnleakInternalPrefix, ip)
+	parentDn := fmt.Sprintf(models.ParentDnleakInternalPrefix, tenant, vrf)
+	leakInternalPrefix := models.NewLeakInternalPrefix(rn, parentDn, description, nameAlias, leakInternalPrefixAttr)
+	leakInternalPrefix.Status = "modified"
+	err := sm.Save(leakInternalPrefix)
+	return leakInternalPrefix, err
+}
+
+func (sm *ServiceManager) ListLeakInternalPrefix(vrf string, tenant string) ([]*models.LeakInternalPrefix, error) {
+	dnUrl := fmt.Sprintf("%s/uni/tn-%s/ctx-%s/leakroutes/leakInternalPrefix.json", models.BaseurlStr, tenant, vrf)
+	cont, err := sm.GetViaURL(dnUrl)
+	list := models.LeakInternalPrefixListFromContainer(cont)
+	return list, err
+}

--- a/models/leak_internal_prefix_subnet.go
+++ b/models/leak_internal_prefix_subnet.go
@@ -1,0 +1,104 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ciscoecosystem/aci-go-client/container"
+)
+
+const (
+	DnleakInternalPrefix        = "uni/tn-%s/ctx-%s/leakroutes/leakintprefix-[%s]"
+	RnleakInternalPrefix        = "leakintprefix-[%s]"
+	ParentDnleakInternalPrefix  = "uni/tn-%s/ctx-%s/leakroutes"
+	LeakInternalPrefixClassName = "leakInternalPrefix"
+)
+
+type LeakInternalPrefix struct {
+	BaseAttributes
+	NameAliasAttribute
+	LeakInternalPrefixAttributes
+}
+
+type LeakInternalPrefixAttributes struct {
+	Annotation      string `json:",omitempty"`
+	Ip              string `json:",omitempty"`
+	Name            string `json:",omitempty"`
+	LessThanOrEqual string `json:",omitempty"`
+}
+
+func NewLeakInternalPrefix(leakInternalPrefixRn, parentDn, description, nameAlias string, leakInternalPrefixAttr LeakInternalPrefixAttributes) *LeakInternalPrefix {
+	dn := fmt.Sprintf("%s/%s", parentDn, leakInternalPrefixRn)
+	return &LeakInternalPrefix{
+		BaseAttributes: BaseAttributes{
+			DistinguishedName: dn,
+			Description:       description,
+			Status:            "created, modified",
+			ClassName:         LeakInternalPrefixClassName,
+			Rn:                leakInternalPrefixRn,
+		},
+		NameAliasAttribute: NameAliasAttribute{
+			NameAlias: nameAlias,
+		},
+		LeakInternalPrefixAttributes: leakInternalPrefixAttr,
+	}
+}
+
+func (leakInternalPrefix *LeakInternalPrefix) ToMap() (map[string]string, error) {
+	leakInternalPrefixMap, err := leakInternalPrefix.BaseAttributes.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	alias, err := leakInternalPrefix.NameAliasAttribute.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range alias {
+		A(leakInternalPrefixMap, key, value)
+	}
+
+	A(leakInternalPrefixMap, "annotation", leakInternalPrefix.Annotation)
+	A(leakInternalPrefixMap, "ip", leakInternalPrefix.Ip)
+	A(leakInternalPrefixMap, "name", leakInternalPrefix.Name)
+	A(leakInternalPrefixMap, "le", leakInternalPrefix.LessThanOrEqual)
+	return leakInternalPrefixMap, err
+}
+
+func LeakInternalPrefixFromContainerList(cont *container.Container, index int) *LeakInternalPrefix {
+	LeakInternalPrefixCont := cont.S("imdata").Index(index).S(LeakInternalPrefixClassName, "attributes")
+	return &LeakInternalPrefix{
+		BaseAttributes{
+			DistinguishedName: G(LeakInternalPrefixCont, "dn"),
+			Description:       G(LeakInternalPrefixCont, "descr"),
+			Status:            G(LeakInternalPrefixCont, "status"),
+			ClassName:         LeakInternalPrefixClassName,
+			Rn:                G(LeakInternalPrefixCont, "rn"),
+		},
+		NameAliasAttribute{
+			NameAlias: G(LeakInternalPrefixCont, "nameAlias"),
+		},
+		LeakInternalPrefixAttributes{
+			Annotation:      G(LeakInternalPrefixCont, "annotation"),
+			Ip:              G(LeakInternalPrefixCont, "ip"),
+			Name:            G(LeakInternalPrefixCont, "name"),
+			LessThanOrEqual: G(LeakInternalPrefixCont, "le"),
+		},
+	}
+}
+
+func LeakInternalPrefixFromContainer(cont *container.Container) *LeakInternalPrefix {
+	return LeakInternalPrefixFromContainerList(cont, 0)
+}
+
+func LeakInternalPrefixListFromContainer(cont *container.Container) []*LeakInternalPrefix {
+	length, _ := strconv.Atoi(G(cont, "totalCount"))
+	arr := make([]*LeakInternalPrefix, length)
+
+	for i := 0; i < length; i++ {
+		arr[i] = LeakInternalPrefixFromContainerList(cont, i)
+	}
+
+	return arr
+}


### PR DESCRIPTION
Note:

Created Cloud APIC leakInternalPrefix model to Leak VRF for the Internal routes, PR belongs to: https://github.com/CiscoDevNet/terraform-provider-aci/issues/807