### PR TITLE
Added parentDn to vnsRedirectDest model and client files

### DIFF
--- a/models/vns_redirect_dest.go
+++ b/models/vns_redirect_dest.go
@@ -7,30 +7,28 @@ import (
 	"github.com/ciscoecosystem/aci-go-client/container"
 )
 
-const VnsredirectdestClassName = "vnsRedirectDest"
+const (
+	RnvnsRedirectDest        = "RedirectDest_ip-[%s]"
+	VnsredirectdestClassName = "vnsRedirectDest"
+)
 
 type Destinationofredirectedtraffic struct {
 	BaseAttributes
+	NameAliasAttribute
 	DestinationofredirectedtrafficAttributes
 }
 
 type DestinationofredirectedtrafficAttributes struct {
-	Ip string `json:",omitempty"`
-
 	Annotation string `json:",omitempty"`
-
-	DestName string `json:",omitempty"`
-
-	Ip2 string `json:",omitempty"`
-
-	Mac string `json:",omitempty"`
-
-	NameAlias string `json:",omitempty"`
-
-	PodId string `json:",omitempty"`
+	DestName   string `json:",omitempty"`
+	Ip         string `json:",omitempty"`
+	Ip2        string `json:",omitempty"`
+	Mac        string `json:",omitempty"`
+	Name       string `json:",omitempty"`
+	PodId      string `json:",omitempty"`
 }
 
-func NewDestinationofredirectedtraffic(vnsRedirectDestRn, parentDn, description string, vnsRedirectDestattr DestinationofredirectedtrafficAttributes) *Destinationofredirectedtraffic {
+func NewDestinationofredirectedtraffic(vnsRedirectDestRn, parentDn, description, nameAlias string, vnsRedirectDestAttr DestinationofredirectedtrafficAttributes) *Destinationofredirectedtraffic {
 	dn := fmt.Sprintf("%s/%s", parentDn, vnsRedirectDestRn)
 	return &Destinationofredirectedtraffic{
 		BaseAttributes: BaseAttributes{
@@ -40,8 +38,10 @@ func NewDestinationofredirectedtraffic(vnsRedirectDestRn, parentDn, description 
 			ClassName:         VnsredirectdestClassName,
 			Rn:                vnsRedirectDestRn,
 		},
-
-		DestinationofredirectedtrafficAttributes: vnsRedirectDestattr,
+		NameAliasAttribute: NameAliasAttribute{
+			NameAlias: nameAlias,
+		},
+		DestinationofredirectedtrafficAttributes: vnsRedirectDestAttr,
 	}
 }
 
@@ -51,25 +51,26 @@ func (vnsRedirectDest *Destinationofredirectedtraffic) ToMap() (map[string]strin
 		return nil, err
 	}
 
-	A(vnsRedirectDestMap, "ip", vnsRedirectDest.Ip)
+	alias, err := vnsRedirectDest.NameAliasAttribute.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	for key, value := range alias {
+		A(vnsRedirectDestMap, key, value)
+	}
 
 	A(vnsRedirectDestMap, "annotation", vnsRedirectDest.Annotation)
-
 	A(vnsRedirectDestMap, "destName", vnsRedirectDest.DestName)
-
+	A(vnsRedirectDestMap, "ip", vnsRedirectDest.Ip)
 	A(vnsRedirectDestMap, "ip2", vnsRedirectDest.Ip2)
-
 	A(vnsRedirectDestMap, "mac", vnsRedirectDest.Mac)
-
-	A(vnsRedirectDestMap, "nameAlias", vnsRedirectDest.NameAlias)
-
+	A(vnsRedirectDestMap, "name", vnsRedirectDest.Name)
 	A(vnsRedirectDestMap, "podId", vnsRedirectDest.PodId)
-
 	return vnsRedirectDestMap, err
 }
 
 func DestinationofredirectedtrafficFromContainerList(cont *container.Container, index int) *Destinationofredirectedtraffic {
-
 	DestinationofredirectedtrafficCont := cont.S("imdata").Index(index).S(VnsredirectdestClassName, "attributes")
 	return &Destinationofredirectedtraffic{
 		BaseAttributes{
@@ -79,38 +80,30 @@ func DestinationofredirectedtrafficFromContainerList(cont *container.Container, 
 			ClassName:         VnsredirectdestClassName,
 			Rn:                G(DestinationofredirectedtrafficCont, "rn"),
 		},
-
-		DestinationofredirectedtrafficAttributes{
-
-			Ip: G(DestinationofredirectedtrafficCont, "ip"),
-
-			Annotation: G(DestinationofredirectedtrafficCont, "annotation"),
-
-			DestName: G(DestinationofredirectedtrafficCont, "destName"),
-
-			Ip2: G(DestinationofredirectedtrafficCont, "ip2"),
-
-			Mac: G(DestinationofredirectedtrafficCont, "mac"),
-
+		NameAliasAttribute{
 			NameAlias: G(DestinationofredirectedtrafficCont, "nameAlias"),
-
-			PodId: G(DestinationofredirectedtrafficCont, "podId"),
+		},
+		DestinationofredirectedtrafficAttributes{
+			Annotation: G(DestinationofredirectedtrafficCont, "annotation"),
+			DestName:   G(DestinationofredirectedtrafficCont, "destName"),
+			Ip:         G(DestinationofredirectedtrafficCont, "ip"),
+			Ip2:        G(DestinationofredirectedtrafficCont, "ip2"),
+			Mac:        G(DestinationofredirectedtrafficCont, "mac"),
+			Name:       G(DestinationofredirectedtrafficCont, "name"),
+			PodId:      G(DestinationofredirectedtrafficCont, "podId"),
 		},
 	}
 }
 
 func DestinationofredirectedtrafficFromContainer(cont *container.Container) *Destinationofredirectedtraffic {
-
 	return DestinationofredirectedtrafficFromContainerList(cont, 0)
 }
 
 func DestinationofredirectedtrafficListFromContainer(cont *container.Container) []*Destinationofredirectedtraffic {
 	length, _ := strconv.Atoi(G(cont, "totalCount"))
-
 	arr := make([]*Destinationofredirectedtraffic, length)
 
 	for i := 0; i < length; i++ {
-
 		arr[i] = DestinationofredirectedtrafficFromContainerList(cont, i)
 	}
 


### PR DESCRIPTION
Note:

Updated vnsRedirectDest model and client files to support multiple DN formats.
```
1. uni/tn-{name}/svcCont/backupPol-{name}/RedirectDest_ip-[{ip}]
2. uni/tn-{name}/svcCont/svcRedirectPol-{name}/RedirectDest_ip-[{ip}]
```