### PR TITLE
Ignore error code 120 when deleting objects

### DIFF
--- a/client/service_manager.go
+++ b/client/service_manager.go
@@ -98,9 +98,9 @@ func CheckForErrors(cont *container.Container, method string, skipLoggingPayload
 					log.Printf("[DEBUG] Exit from error 103 %v", cont)
 				}
 				return nil
-			} else if method == "DELETE" && (errorCode == "1" || errorCode == "107") { // Ignore errors of type "Cannot delete object"
+			} else if method == "DELETE" && (errorCode == "1" || errorCode == "107" || errorCode == "120") { // Ignore errors of type "Cannot delete object"
 				if !skipLoggingPayload {
-					log.Printf("[DEBUG] Exit from error 1 or 107 %v", cont)
+					log.Printf("[DEBUG] Exit from error 1, 107 or 120 %v", cont)
 				}
 				return nil
 			} else {


### PR DESCRIPTION
120 is another error code thrown when an object cannot be deleted.

```
DELETE https://sandboxapicdc.cisco.com/api/mo/uni/tn-TF/ap-AP1/epg-APP/rsdomAtt-[uni/vmmp-VMware/dom-VMW1]/uplinkorder.json

{
    "totalCount": "1",
    "imdata": [
        {
            "error": {
                "attributes": {
                    "code": "120",
                    "text": "Uplink Failover Order can not be deleted."
                }
            }
        }
    ]
}
```

