### PR TITLE
Added support for l3ext:consLbl 

### DIFF
--- a/client/l3extConsLbl_service.go
+++ b/client/l3extConsLbl_service.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/ciscoecosystem/aci-go-client/v2/models"
+)
+
+func (sm *ServiceManager) CreateL3ExtConsLbl(name string, l3_outside string, tenant string, description string, consLblAttr models.L3ExtConsLblAttributes) (*models.L3ExtConsLbl, error) {
+	rn := fmt.Sprintf(models.RnL3extConsLbl, name)
+	parentDn := fmt.Sprintf(models.ParentDnL3ExtConsLbl, tenant, l3_outside)
+	consLbl := models.NewL3ExtConsLbl(rn, parentDn, description, consLblAttr)
+	err := sm.Save(consLbl)
+	return consLbl, err
+}
+
+func (sm *ServiceManager) ReadL3ExtConsLbl(name string, l3_outside string, tenant string) (*models.L3ExtConsLbl, error) {
+	dn := fmt.Sprintf(models.DnL3extConsLbl, tenant, l3_outside, name)
+	cont, err := sm.Get(dn)
+	if err != nil {
+		return nil, err
+	}
+
+	consLbl := models.L3ExtConsLblFromContainer(cont)
+	return consLbl, nil
+}
+
+func (sm *ServiceManager) DeleteL3ExtConsLbl(name string, l3_outside string, tenant string) error {
+	dn := fmt.Sprintf(models.DnL3extConsLbl, tenant, l3_outside, name)
+	return sm.DeleteByDn(dn, models.L3extConsLblClassName)
+}
+
+func (sm *ServiceManager) UpdateL3ExtConsLbl(name string, l3_outside string, tenant string, description string, consLblAttr models.L3ExtConsLblAttributes) (*models.L3ExtConsLbl, error) {
+	rn := fmt.Sprintf(models.RnL3extConsLbl, name)
+	parentDn := fmt.Sprintf(models.ParentDnL3ExtConsLbl, tenant, l3_outside)
+	consLbl := models.NewL3ExtConsLbl(rn, parentDn, description, consLblAttr)
+
+	consLbl.Status = "modified"
+	err := sm.Save(consLbl)
+	return consLbl, err
+}

--- a/models/l3ext_cons_lbl.go
+++ b/models/l3ext_cons_lbl.go
@@ -20,15 +20,11 @@ type L3ExtConsLbl struct {
 }
 
 type L3ExtConsLblAttributes struct {
-	Name string `json:",omitempty"`
-
+	Name       string `json:",omitempty"`
 	Annotation string `json:",omitempty"`
-
-	NameAlias string `json:",omitempty"`
-
-	Owner string `json:",omitempty"`
-
-	Tag string `json:",omitempty"`
+	NameAlias  string `json:",omitempty"`
+	Owner      string `json:",omitempty"`
+	Tag        string `json:",omitempty"`
 }
 
 func NewL3ExtConsLbl(consLblRn, parentDn, description string, consLblAttr L3ExtConsLblAttributes) *L3ExtConsLbl {
@@ -53,15 +49,10 @@ func (consLbl *L3ExtConsLbl) ToMap() (map[string]string, error) {
 	}
 
 	A(consLblMap, "name", consLbl.Name)
-
 	A(consLblMap, "annotation", consLbl.Annotation)
-
 	A(consLblMap, "nameAlias", consLbl.NameAlias)
-
 	A(consLblMap, "owner", consLbl.Owner)
-
 	A(consLblMap, "tag", consLbl.Tag)
-
 	return consLblMap, err
 }
 
@@ -77,15 +68,10 @@ func L3ExtConsLblFromContainerList(cont *container.Container, index int) *L3ExtC
 		},
 
 		L3ExtConsLblAttributes{
-
 			Name: G(L3ExtConsLblCont, "name"),
-
 			Annotation: G(L3ExtConsLblCont, "annotation"),
-
 			NameAlias: G(L3ExtConsLblCont, "nameAlias"),
-
 			Owner: G(L3ExtConsLblCont, "owner"),
-
 			Tag: G(L3ExtConsLblCont, "tag"),
 		},
 	}
@@ -99,9 +85,7 @@ func L3ExtConsLblListFromContainer(cont *container.Container) []*L3ExtConsLbl {
 	length, _ := strconv.Atoi(G(cont, "totalCount"))
 
 	arr := make([]*L3ExtConsLbl, length)
-
 	for i := 0; i < length; i++ {
-
 		arr[i] = L3ExtConsLblFromContainerList(cont, i)
 	}
 

--- a/models/l3ext_cons_lbl.go
+++ b/models/l3ext_cons_lbl.go
@@ -1,0 +1,109 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ciscoecosystem/aci-go-client/v2/container"
+)
+
+const (
+	DnL3extConsLbl        = "uni/tn-%s/out-%s/conslbl-%s"
+	RnL3extConsLbl        = "conslbl-%s"
+	ParentDnL3ExtConsLbl  = "uni/tn-%s/out-%s"
+	L3extConsLblClassName = "l3extConsLbl"
+)
+
+type L3ExtConsLbl struct {
+	BaseAttributes
+	L3ExtConsLblAttributes
+}
+
+type L3ExtConsLblAttributes struct {
+	Name string `json:",omitempty"`
+
+	Annotation string `json:",omitempty"`
+
+	NameAlias string `json:",omitempty"`
+
+	Owner string `json:",omitempty"`
+
+	Tag string `json:",omitempty"`
+}
+
+func NewL3ExtConsLbl(consLblRn, parentDn, description string, consLblAttr L3ExtConsLblAttributes) *L3ExtConsLbl {
+	dn := fmt.Sprintf("%s/%s", parentDn, consLblRn)
+	return &L3ExtConsLbl{
+		BaseAttributes: BaseAttributes{
+			DistinguishedName: dn,
+			Description:       description,
+			Status:            "created, modified",
+			ClassName:         L3extConsLblClassName,
+			Rn:                consLblRn,
+		},
+
+		L3ExtConsLblAttributes: consLblAttr,
+	}
+}
+
+func (consLbl *L3ExtConsLbl) ToMap() (map[string]string, error) {
+	consLblMap, err := consLbl.BaseAttributes.ToMap()
+	if err != nil {
+		return nil, err
+	}
+
+	A(consLblMap, "name", consLbl.Name)
+
+	A(consLblMap, "annotation", consLbl.Annotation)
+
+	A(consLblMap, "nameAlias", consLbl.NameAlias)
+
+	A(consLblMap, "owner", consLbl.Owner)
+
+	A(consLblMap, "tag", consLbl.Tag)
+
+	return consLblMap, err
+}
+
+func L3ExtConsLblFromContainerList(cont *container.Container, index int) *L3ExtConsLbl {
+	L3ExtConsLblCont := cont.S("imdata").Index(index).S(L3extConsLblClassName, "attributes")
+	return &L3ExtConsLbl{
+		BaseAttributes{
+			DistinguishedName: G(L3ExtConsLblCont, "dn"),
+			Description:       G(L3ExtConsLblCont, "descr"),
+			Status:            G(L3ExtConsLblCont, "status"),
+			ClassName:         L3extConsLblClassName,
+			Rn:                G(L3ExtConsLblCont, "rn"),
+		},
+
+		L3ExtConsLblAttributes{
+
+			Name: G(L3ExtConsLblCont, "name"),
+
+			Annotation: G(L3ExtConsLblCont, "annotation"),
+
+			NameAlias: G(L3ExtConsLblCont, "nameAlias"),
+
+			Owner: G(L3ExtConsLblCont, "owner"),
+
+			Tag: G(L3ExtConsLblCont, "tag"),
+		},
+	}
+}
+
+func L3ExtConsLblFromContainer(cont *container.Container) *L3ExtConsLbl {
+	return L3ExtConsLblFromContainerList(cont, 0)
+}
+
+func L3ExtConsLblListFromContainer(cont *container.Container) []*L3ExtConsLbl {
+	length, _ := strconv.Atoi(G(cont, "totalCount"))
+
+	arr := make([]*L3ExtConsLbl, length)
+
+	for i := 0; i < length; i++ {
+
+		arr[i] = L3ExtConsLblFromContainerList(cont, i)
+	}
+
+	return arr
+}


### PR DESCRIPTION
Hi,

As discussed with Akini - I've decided to help you contributing to aci provider since my personal list of resources that are not supported yet in terraform aci provider contains some entries, so I've decided to start working on it and help you implement them - on the other hand I'll be able to use them in my environment once implemented. For the first shot I picked l3out:consLbl just to familiarize with a project.

No more talking - let's cut to the chase.

This PR is created to add support for CRUD operations for l3ext:consLbl. Please carry out review, thank you. Once reviewed and merged - I'll go further with declaring new resource + and data source ACI provider.

Issue: https://github.com/CiscoDevNet/terraform-provider-aci/issues/979

Thanks
Mateusz 